### PR TITLE
Changed default port to 80

### DIFF
--- a/chrome-localhost/options.js
+++ b/chrome-localhost/options.js
@@ -6,7 +6,7 @@ function save_options() {
 function restore_options() {
   var port = localStorage["port_value"];
   if (port == null)
-    port = "3000";
+    port = "80";
   document.getElementById("port_text").value = port;
 }
 


### PR DESCRIPTION
Many developers working on localhost have it set to port 80 by default. It appears to be the number one request in the chrome store by reviewers. All I have done is changed the default port option from 3000 to 80.
